### PR TITLE
Verify user merged PRs logic is correct - Fixes #4

### DIFF
--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -1,0 +1,40 @@
+# User Merged PRs Logic Verification
+
+## Issue #4 Verification
+
+This document confirms the verification of issue #4: "[fix]: confirm that you checking if the user's PRs were merged not the user merged PRs"
+
+## Current Logic Analysis
+
+The current implementation in `src/lib/github.ts` (lines 194-196) correctly implements the required logic:
+
+```typescript
+// Check if this is the target user's PR
+if (pr.user?.login === username) {
+  userMergedPRs++;
+}
+```
+
+## Verification Results
+
+✅ **LOGIC IS CORRECT** - The current implementation properly counts:
+
+1. **PRs authored by the user** (`pr.user.login === username`)
+2. **That were merged** (filtered by `pr.merged_at` being not null)
+3. **Within the specified date range** (filtered by date comparison)
+
+## What the Logic Does NOT Do
+
+❌ The logic does NOT count PRs that the user personally merged (which would be `pr.merged_by?.login === username`)
+
+## Form Text Verification
+
+The form correctly displays: "You personally authored ≥5 merged PRs across the repo/org in the last 90 days."
+
+This matches exactly what the current logic implements.
+
+## Conclusion
+
+**No code changes are required.** The current logic correctly identifies PRs authored by the user that were merged, which is exactly what was requested in the issue.
+
+The statistic represents "PRs authored by the user that were merged" NOT "PRs the user personally merged."


### PR DESCRIPTION
## Summary

This PR addresses issue #4 by verifying that the current logic for counting "User Merged PRs" is correct.

## Analysis Results

✅ **The current logic is CORRECT** and no code changes are needed.

## What the Current Logic Does

The implementation in `src/lib/github.ts` (lines 194-196) correctly:

1. **Counts PRs authored by the user** (`pr.user.login === username`)
2. **That were merged** (filtered by `pr.merged_at` being not null)  
3. **Within the specified date range** (90 days)

## What the Logic Does NOT Do

❌ The logic does NOT count PRs that the user personally merged (which would be `pr.merged_by?.login === username`)

## Form Text Verification

The form correctly displays: *"You personally authored ≥5 merged PRs across the repo/org in the last 90 days."*

This matches exactly what the current logic implements.

## Conclusion

The current implementation correctly identifies **PRs authored by the user that were merged**, which is exactly what was requested in the issue. The statistic represents "PRs authored by the user that were merged" NOT "PRs the user personally merged."

## Changes Made

- Added `VERIFICATION.md` documenting the analysis and confirmation that the logic is correct
- No functional code changes were needed

Fixes #4

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8f96adad6564477db2dee485bdab043f)